### PR TITLE
DEV: replace widget home-logo with glimmer component and adjust styling class

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -15,11 +15,11 @@
     right: 0;
     top: 0;
   }
-  &__logo a {
-    color: var(--primary);
-  }
   #site-logo {
     max-width: calc(100% / 4);
+  }
+  .text-logo {
+    color: var(--primary);
   }
 }
 

--- a/javascripts/discourse/components/add-to-homescreen.hbs
+++ b/javascripts/discourse/components/add-to-homescreen.hbs
@@ -12,7 +12,7 @@
       (if this.animate "animate")
     }}
   >
-    <MountWidget @widget="home-logo" class="add-to-homescreen-outlet__logo" />
+    <Header::HomeLogo />
     <span class="add-to-homescreen__description">
       {{html-safe this.PWALabel}}
       {{#if this.arrowUp}}


### PR DESCRIPTION
Part of upgrading themes to use glimmer header.

### After
<img width="415" alt="after" src="https://github.com/discourse/discourse-apple-add-to-homescreen/assets/133760061/4b0f49c8-841d-41b0-b42a-cf1927593787">

Applying style more specifically to `text-logo`:
<img width="740" alt="text-styling" src="https://github.com/discourse/discourse-apple-add-to-homescreen/assets/133760061/c6e562d7-5b3c-4aa7-9ddc-704497f3d817">
